### PR TITLE
Add 'trial_ends_at' to RecurlyConstants.

### DIFF
--- a/src/main/java/za/co/trf/recurly/RecurlyConstants.java
+++ b/src/main/java/za/co/trf/recurly/RecurlyConstants.java
@@ -12,6 +12,7 @@ public class RecurlyConstants {
     public final static String JS_PARAM_QUANTITY = "quantity";
     public final static String JS_PARAM_SUBSCRIPTION = "subscription";
     public final static String JS_PARAM_TRANSACTION = "transaction";
+    public final static String JS_PARAM_TRIAL_ENDS_AT = "trial_ends_at";
     public final static String JS_PARAM_AMOUNT_IN_CENTS = "amount_in_cents";
     public final static String JS_PARAM_CURRENCY = "currency";
     public final static String JS_PARAM_COUPON_CODE = "coupon_code";


### PR DESCRIPTION
We're using this constant in our Recurly integration. I want to add it to RecurlyConstants to keep our use of Recurly related constants consistent.
